### PR TITLE
Hot fix/log display name

### DIFF
--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -48,7 +48,7 @@ module.exports = {
 		var logMsg = "";
 		if (interaction.inGuild()){
 			let guildInfo = "(Guild ID: " + interaction.guildId + ") " + interaction.guild.name + "'s "
-			let playerInfo = interaction.member.nickname + " (ID: " + (interaction.member.id) + ") called ";
+			let playerInfo = interaction.member.displayName + " (ID: " + (interaction.member.id) + ") called ";
 			logMsg = guildInfo + playerInfo;
 		}
 		else {


### PR DESCRIPTION
Rather than only logging the nickname the logger now logs the display name. This logs a nickname if they have it but a user name if not. This addresses the issue of not logging a name if a user doesn't have a nickname